### PR TITLE
Registration Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ WAGGLE_BEEHIVE_HOST=host.docker.internal
 
 ### Registration
 
-If you have a registration key, it should be placed in `private/register.pem`. If you do not have a registration key, registration will fall back to directly querying a cert server. This behavior is generally only intended for local development when running a beehive server and node test environment on the same machine.
+If you have a registration key, it should be placed in `private/register.pem` and made sure it has permissions `0600`.
+
+If you do not have a registration key, registration will fall back to directly querying a cert server. This behavior is generally only intended for local development when running a beehive server and node test environment on the same machine.
 
 ### Running the Node Environment
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ WAGGLE_BEEHIVE_HOST=host.docker.internal
 # WAGGLE_BEEHIVE_HOST=beehive1.mcs.anl.gov
 ```
 
+### Registration
+
+If you have a registration key, it should be placed in `private/register.pem`. If you do not have a registration key, registration will fall back to directly querying a cert server. This behavior is generally only intended for local development when running a beehive server and node test environment on the same machine.
+
 ### Running the Node Environment
 
 To start the node environment, run:

--- a/services/registration/Dockerfile
+++ b/services/registration/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+RUN apk add openssh-client
+
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./

--- a/utils/set-node-plugins.py
+++ b/utils/set-node-plugins.py
@@ -110,7 +110,7 @@ args = parser.parse_args()
 services = []
 
 for plugin in args.plugins:
-    match = re.match(r'waggle/plugin-(\S+):(\S+)', plugin)
+    match = re.match(r'plugin-(\S+):(\S+)', plugin.split('/')[-1])
     plugin_name = match.group(1)
     plugin_version = match.group(2)
 


### PR DESCRIPTION
The registration service now support registering over ssh if a registration key exists, but will fallback to directly querying a local cert server otherwise. This is useful when being used for development.